### PR TITLE
feat: add support for Ariston Lydos Wifi's boost mode

### DIFF
--- a/ariston/__init__.py
+++ b/ariston/__init__.py
@@ -4,8 +4,6 @@ import asyncio
 import logging
 from typing import Any, Optional, Type
 
-from ariston.lydos_device import AristonLydosDevice
-
 from .ariston_api import AristonAPI, ConnectionException
 from .const import (
     ARISTON_API_URL,
@@ -25,6 +23,7 @@ from .lydos_hybrid_device import AristonLydosHybridDevice
 from .nuos_split_device import AristonNuosSplitDevice
 from .base_device import AristonBaseDevice
 from .velis_base_device import AristonVelisBaseDevice
+from .lydos_device import AristonLydosDevice
 
 _LOGGER = logging.getLogger(__name__)
 

--- a/ariston/__init__.py
+++ b/ariston/__init__.py
@@ -1,7 +1,10 @@
 """Ariston module"""
+
 import asyncio
 import logging
 from typing import Any, Optional
+
+from ariston.lydos_device import AristonLydosDevice
 
 from .ariston_api import AristonAPI, ConnectionException
 from .const import (
@@ -26,13 +29,14 @@ _LOGGER = logging.getLogger(__name__)
 _MAP_WHE_TYPES_TO_CLASS = {
     WheType.Evo.value: AristonEvoOneDevice,
     WheType.LydosHybrid.value: AristonLydosHybridDevice,
-    WheType.Lydos.value: AristonEvoDevice,
+    WheType.Lydos.value: AristonLydosDevice,
     WheType.NuosSplit.value: AristonNuosSplitDevice,
     WheType.Andris2.value: AristonEvoDevice,
     WheType.Evo2.value: AristonEvoDevice,
     WheType.Lux2.value: AristonLux2Device,
     WheType.Lux.value: AristonLuxDevice,
 }
+
 
 class Ariston:
     """Ariston class"""
@@ -114,7 +118,9 @@ def _get_device(
             return None
 
 
-def _connect(username: str, password: str, api_url: str = ARISTON_API_URL) -> AristonAPI:
+def _connect(
+    username: str, password: str, api_url: str = ARISTON_API_URL
+) -> AristonAPI:
     """Connect to ariston api"""
     api = AristonAPI(username, password, api_url)
     api.connect()
@@ -130,7 +136,9 @@ def _discover(api: AristonAPI) -> list[dict[str, Any]]:
     return cloud_devices
 
 
-def discover(username: str, password: str, api_url: str = ARISTON_API_URL) -> list[dict[str, Any]]:
+def discover(
+    username: str, password: str, api_url: str = ARISTON_API_URL
+) -> list[dict[str, Any]]:
     """Retreive ariston devices from the cloud"""
     api = _connect(username, password, api_url)
     return _discover(api)
@@ -150,7 +158,9 @@ def hello(
     return _get_device(cloud_devices, api, gateway, is_metric, language_tag)
 
 
-async def _async_connect(username: str, password: str, api_url: str = ARISTON_API_URL) -> AristonAPI:
+async def _async_connect(
+    username: str, password: str, api_url: str = ARISTON_API_URL
+) -> AristonAPI:
     """Async connect to ariston api"""
     api = AristonAPI(username, password, api_url)
     if not await api.async_connect():
@@ -173,7 +183,9 @@ async def _async_discover(api: AristonAPI) -> list[dict[str, Any]]:
     return cloud_devices
 
 
-async def async_discover(username: str, password: str, api_url: str = ARISTON_API_URL) -> list[dict[str, Any]]:
+async def async_discover(
+    username: str, password: str, api_url: str = ARISTON_API_URL
+) -> list[dict[str, Any]]:
     """Retreive ariston devices from the cloud"""
     api = await _async_connect(username, password, api_url)
     return await _async_discover(api)

--- a/ariston/lydos_device.py
+++ b/ariston/lydos_device.py
@@ -1,0 +1,39 @@
+"""Evo device class for Ariston module."""
+
+from __future__ import annotations
+
+import logging
+
+from .const import (
+    EvoDeviceProperties,
+    LuxPlantMode,
+    WaterHeaterMode,
+)
+from .evo_device import AristonEvoDevice
+
+_LOGGER = logging.getLogger(__name__)
+
+
+class AristonLydosDevice(AristonEvoDevice):
+    """Class representing a physical Lydos Wi-Fi device, it's state and properties."""
+
+    @property
+    def water_heater_mode(self) -> type[WaterHeaterMode]:
+        """Return the water heater mode class"""
+        return LuxPlantMode
+
+    def set_water_heater_operation_mode(self, operation_mode: str):
+        """Set water heater operation mode"""
+        self.api.set_evo_mode(self.gw, self.water_heater_mode[operation_mode])
+        self.data[EvoDeviceProperties.MODE] = self.water_heater_mode[
+            operation_mode
+        ].value
+
+    async def async_set_water_heater_operation_mode(self, operation_mode: str):
+        """Async set water heater operation mode"""
+        await self.api.async_set_evo_mode(
+            self.gw, self.water_heater_mode[operation_mode]
+        )
+        self.data[EvoDeviceProperties.MODE] = self.water_heater_mode[
+            operation_mode
+        ].value


### PR DESCRIPTION
This should address fustom/ariston-remotethermo-home-assistant-v3#364 from the Home Assistant integration.

I've locally tested this and it works on my device. Boost mode is actually a pretty useful mode in my case, and I hated that I was forced to use the app to trigger it. Hopefully this solves the issue. 

---

## Disclaimer
I reused the `ariston.const.LuxPlantMode`, because it's the same. I don't think it's inherently wrong, but you may not like it. 

--- 

Correct me if I'm wrong, but I presume no particular changes (besides upgrading the dependency) is needed in fustom/ariston-remotethermo-home-assistant-v3 to make this feature appear in Home Assistant.