### PR TITLE
Fix NuosSplit operative mode changes (GREEN mode not working)

### DIFF
--- a/ariston/ariston_api.py
+++ b/ariston/ariston_api.py
@@ -265,12 +265,15 @@ class AristonAPI:
             },
         )
 
-    def set_nuos_mode(self, gw_id: str, value: NuosSplitOperativeMode) -> None:
+    def set_nuos_mode(
+        self, gw_id: str, value: NuosSplitOperativeMode, old_value: int
+    ) -> None:
         """Set Velis Nuos mode"""
         self._post(
             f"{self.__api_url}{ARISTON_VELIS}/{PlantData.Slp.value}/{gw_id}/operativeMode",
             {
                 "new": value.value,
+                "old": old_value,
             },
         )
 
@@ -726,13 +729,14 @@ class AristonAPI:
         )
 
     async def async_set_nuos_mode(
-        self, gw_id: str, value: NuosSplitOperativeMode
+        self, gw_id: str, value: NuosSplitOperativeMode, old_value: int
     ) -> None:
         """Async set Velis Nuos mode"""
         await self._async_post(
             f"{self.__api_url}{ARISTON_VELIS}/{PlantData.Slp.value}/{gw_id}/operativeMode",
             {
                 "new": value.value,
+                "old": old_value,
             },
         )
 

--- a/ariston/nuos_split_device.py
+++ b/ariston/nuos_split_device.py
@@ -174,17 +174,21 @@ class AristonNuosSplitDevice(AristonVelisDevice):
 
     def set_water_heater_operation_mode(self, operation_mode: str):
         """Set water heater operation mode"""
-        self.api.set_nuos_mode(self.gw, NuosSplitOperativeMode[operation_mode])
-        self.data[NuosSplitProperties.MODE] = NuosSplitOperativeMode[
+        old_value = self.water_heater_mode_value if self.water_heater_mode_value is not None else 1
+        self.api.set_nuos_mode(
+            self.gw, NuosSplitOperativeMode[operation_mode], old_value
+        )
+        self.data[NuosSplitProperties.OP_MODE] = NuosSplitOperativeMode[
             operation_mode
         ].value
 
     async def async_set_water_heater_operation_mode(self, operation_mode: str):
         """Async set water heater operation mode"""
+        old_value = self.water_heater_mode_value if self.water_heater_mode_value is not None else 1
         await self.api.async_set_nuos_mode(
-            self.gw, NuosSplitOperativeMode[operation_mode]
+            self.gw, NuosSplitOperativeMode[operation_mode], old_value
         )
-        self.data[NuosSplitProperties.MODE] = NuosSplitOperativeMode[
+        self.data[NuosSplitProperties.OP_MODE] = NuosSplitOperativeMode[
             operation_mode
         ].value
 


### PR DESCRIPTION
## Problem
Setting the operative mode on NuosSplit devices (e.g., Nuos Plus S2) via `set_nuos_mode()` / `async_set_nuos_mode()` returned `{"success": true}` but the mode never actually changed.

### Root Cause
The Ariston API requires the `"old"` field in the request payload to apply operative mode changes. The library was only sending `{"new": value}`.

### Fix
- Updated `set_nuos_mode()` and `async_set_nuos_mode()` in `ariston_api.py` to accept and include the `old_value` parameter
- Updated `set_water_heater_operation_mode()` and `async_set_water_heater_operation_mode()` in `nuos_split_device.py` to pass the current mode value as `old`

### Before
```python
{"new": 0}  # Accepted but ignored
```

### After
```python
{"new": 0, "old": 1}  # Actually applies the change
```

Related to https://github.com/fustom/ariston-remotethermo-home-assistant-v3/issues/407