### PR TITLE
fix: correct sync request timeout from 30000 to 30 seconds

### DIFF
--- a/ariston/ariston_api.py
+++ b/ariston/ariston_api.py
@@ -482,7 +482,7 @@ class AristonAPI:
             params,
         )
         response = requests.request(
-            method, path, params=params, json=body, headers=headers, timeout=30000
+            method, path, params=params, json=body, headers=headers, timeout=30
         )
         if not response.ok:
             match response.status_code:


### PR DESCRIPTION
The `requests.request()` `timeout` parameter is expressed in seconds, not milliseconds. The previous value of 30000 meant ~8 hours, so a hung connection would block the caller indefinitely instead of failing fast. Align with a 30 second timeout.