### PR TITLE
fix: add explicit timeout to async aiohttp requests

### DIFF
--- a/ariston/ariston_api.py
+++ b/ariston/ariston_api.py
@@ -944,7 +944,11 @@ class AristonAPI:
             params,
         )
 
-        async with aiohttp.ClientSession() as session:
+        # Apply an explicit total timeout so a stalled request fails fast
+        # instead of relying on aiohttp's 5 minute default. This mirrors the
+        # 30 second timeout used by the synchronous `requests` path.
+        timeout = aiohttp.ClientTimeout(total=30)
+        async with aiohttp.ClientSession(timeout=timeout) as session:
             response = await session.request(
                 method, path, params=params, json=body, headers=headers
             )


### PR DESCRIPTION
The async request path created a new `aiohttp.ClientSession()` without specifying a timeout, which falls back to aiohttp's default of 5 minutes. The synchronous `requests` path uses a 30 second timeout, so a hung connection produced very different failure modes between the two code paths.

Pass an explicit `ClientTimeout(total=30)` to the session to align the async path with the sync path and to fail fast when the upstream service is unresponsive.