### PR TITLE
fix: keep Nuos optimistic cache in sync with target temperature getter

### DIFF
--- a/ariston/nuos_split_device.py
+++ b/ariston/nuos_split_device.py
@@ -125,7 +125,12 @@ class AristonNuosSplitDevice(AristonVelisDevice):
     def _set_water_heater_temperature(self, temperature: float, reduced: float):
         """Set water heater temperature"""
         self.api.set_nuos_temperature(self.gw, temperature, reduced, self.water_heater_target_temperature, self.water_heater_reduced_temperature)
-        self.data[NuosSplitProperties.PROC_REQ_TEMP] = temperature
+        # Mirror what the cloud now stores. The /temperatures endpoint sets
+        # `comfortTemp` and `reducedTemp`; `procReqTemp` is a separate,
+        # device-driven field. Writing to it here did not match what the
+        # `water_heater_target_temperature` getter reads back, so the
+        # optimistic cache update was invisible until the next refresh.
+        self.data[NuosSplitProperties.COMFORT_TEMP] = temperature
         self.data[NuosSplitProperties.REDUCED_TEMP] = reduced
 
     def set_water_heater_temperature(self, temperature: float):
@@ -142,7 +147,10 @@ class AristonNuosSplitDevice(AristonVelisDevice):
     ):
         """Async set water heater temperature"""
         await self.api.async_set_nuos_temperature(self.gw, temperature, reduced, self.water_heater_target_temperature, self.water_heater_reduced_temperature)
-        self.data[NuosSplitProperties.PROC_REQ_TEMP] = temperature
+        # See note in `_set_water_heater_temperature`: the cloud /temperatures
+        # endpoint updates `comfortTemp` and `reducedTemp`, so the optimistic
+        # cache must mirror those fields, not `procReqTemp`.
+        self.data[NuosSplitProperties.COMFORT_TEMP] = temperature
         self.data[NuosSplitProperties.REDUCED_TEMP] = reduced
 
     async def async_set_water_heater_temperature(self, temperature: float):


### PR DESCRIPTION
`AristonNuosSplitDevice._set_water_heater_temperature` (and its async counterpart) wrote the new comfort temperature into `NuosSplitProperties.PROC_REQ_TEMP`, but
`water_heater_target_temperature` reads from
`NuosSplitProperties.COMFORT_TEMP`. As a result, after a successful `set_water_heater_temperature(...)` call the property continued to return the old value until the next `update_state()` round-trip, producing a misleading stale read for any consumer (e.g. a Home Assistant entity displaying the setpoint).

The cloud `/temperatures` endpoint updates `comfortTemp` and `reducedTemp` on the server side, so mirroring those exact fields in the local cache is the correct optimistic update. `procReqTemp` is a distinct, device-driven field and should not be overwritten by the client.