### PR TITLE
fix: keep Nuos operation mode cache in sync with mode getter

### DIFF
--- a/ariston/nuos_split_device.py
+++ b/ariston/nuos_split_device.py
@@ -175,7 +175,14 @@ class AristonNuosSplitDevice(AristonVelisDevice):
     def set_water_heater_operation_mode(self, operation_mode: str):
         """Set water heater operation mode"""
         self.api.set_nuos_mode(self.gw, NuosSplitOperativeMode[operation_mode])
-        self.data[NuosSplitProperties.MODE] = NuosSplitOperativeMode[
+        # The Nuos cloud payload exposes two distinct fields: `mode` (the
+        # plant mode shared with other Velis devices) and `opMode` (the
+        # operative mode specific to Nuos: GREEN / COMFORT / FAST / IMEMORY).
+        # `set_nuos_mode` posts to `/operativeMode`, so the server updates
+        # `opMode`. The `water_heater_mode_value` getter also reads `opMode`,
+        # so the optimistic cache update has to mirror that field, not the
+        # generic `mode`.
+        self.data[NuosSplitProperties.OP_MODE] = NuosSplitOperativeMode[
             operation_mode
         ].value
 
@@ -184,7 +191,10 @@ class AristonNuosSplitDevice(AristonVelisDevice):
         await self.api.async_set_nuos_mode(
             self.gw, NuosSplitOperativeMode[operation_mode]
         )
-        self.data[NuosSplitProperties.MODE] = NuosSplitOperativeMode[
+        # See note in `set_water_heater_operation_mode`: the cloud
+        # /operativeMode endpoint updates `opMode`, which is also what the
+        # `water_heater_mode_value` getter reads.
+        self.data[NuosSplitProperties.OP_MODE] = NuosSplitOperativeMode[
             operation_mode
         ].value
 


### PR DESCRIPTION
`AristonNuosSplitDevice.set_water_heater_operation_mode` (and its async counterpart) wrote the new operative mode into `NuosSplitProperties.MODE` (the generic Velis `mode` field), but `water_heater_mode_value` reads from `NuosSplitProperties.OP_MODE` (the Nuos-specific `opMode` field).

The Nuos cloud payload exposes both fields with distinct semantics: `mode` is the plant mode shared with other Velis devices, while `opMode` is the Nuos operative mode (GREEN / COMFORT / FAST / IMEMORY). The `set_nuos_mode` API call posts to `/operativeMode`, so the server only updates `opMode`. Mirroring `mode` in the local cache therefore had two unwanted effects:

* `water_heater_mode_value` continued to return the stale `opMode` value until the next `update_state()` round-trip.
* The unrelated `mode` field was clobbered with an `opMode` value, briefly corrupting any caller reading the plant mode from the cache before the next refresh.

This is the same class of bug that #180 fixes for the temperature setter; the operation mode setter just slipped through the same review.